### PR TITLE
Add customizable menubar title formatting, time placeholders, and optional rainbow effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Song name in menubar
 - default menubar format: `{playbackSymbol} [{artist} - ]{title}`
 - available format placeholders: `{playbackSymbol}`, `{artist}`, `{title}`, `{album}`, `{position}`, `{duration}`, `{remaining}`
 - optional format segments: text inside `[...]` appears only when all placeholders in it have values
+- optional rainbow title effect while music is playing, with adjustable hue spacing and saturation
 - hover over song name to see full song name, artist, and album
 - control music playback with a click and hold on song name to play/pause, click and drag right to skip, click and drag left to go back
 - opening menubar application shows album art, full song name, artist, and album

--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ Download and unzip the [latest release](https://github.com/abeljohn/spotify-now-
 ## Features
 
 Song name in menubar
-- configurable menubar format with placeholders for playback status, artist, title, and album
+- configurable menubar format with placeholders for playback status, artist, title, album, and playback time
+- default menubar format: `{playbackSymbol} [{artist} - ]{title}`
+- available format placeholders: `{playbackSymbol}`, `{artist}`, `{title}`, `{album}`, `{position}`, `{duration}`, `{remaining}`
+- optional format segments: text inside `[...]` appears only when all placeholders in it have values
 - hover over song name to see full song name, artist, and album
 - control music playback with a click and hold on song name to play/pause, click and drag right to skip, click and drag left to go back
 - opening menubar application shows album art, full song name, artist, and album

--- a/README.md
+++ b/README.md
@@ -16,15 +16,13 @@ Download and unzip the [latest release](https://github.com/abeljohn/spotify-now-
 ## Features
 
 Song name in menubar
-- optional playing indicator to show song is playing
-- shortens song name by hiding parentheticals
+- configurable menubar format with placeholders for playback status, artist, title, and album
 - hover over song name to see full song name, artist, and album
 - control music playback with a click and hold on song name to play/pause, click and drag right to skip, click and drag left to go back
 - opening menubar application shows album art, full song name, artist, and album
-- alternatively, the song name can be hidden to reduce menubar clutter
 
-<img src="screenshots/menubar_11_light.png" alt="menubar screenshot light mode" title="Song name displayed with playing indicator" width="40%">
-<img src="screenshots/menubar_11_dark.png" alt="menubar screenshot dark mode" title="Song name displayed with playing indicator" width="40%">
+<img src="screenshots/menubar_11_light.png" alt="menubar screenshot light mode" title="Song name displayed in the menubar" width="40%">
+<img src="screenshots/menubar_11_dark.png" alt="menubar screenshot dark mode" title="Song name displayed in the menubar" width="40%">
 
 <img src="screenshots/app_11_light.png" alt="application screenshot light mode" title="Expanded menubar application" width="40%">
 <img src="screenshots/app_11_dark.png" alt="application screenshot dark mode" title="Expanded menubar application" width="40%">

--- a/Spotify Now Playing.xcodeproj/project.pbxproj
+++ b/Spotify Now Playing.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		B5CA8D45228E0A82004097C7 /* PFMoveApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CA8D44228E0A82004097C7 /* PFMoveApplication.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		B5F011032C2C000000000001 /* SNPMenuBarTitleFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = B5F011022C2C000000000001 /* SNPMenuBarTitleFormatter.m */; };
 		B5DA5B73228BC6EE00900729 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B5DA5B72228BC6EE00900729 /* AppDelegate.m */; };
 		B5DA5B76228BC6EE00900729 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5DA5B75228BC6EE00900729 /* ViewController.m */; };
 		B5DA5B78228BC6EF00900729 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B5DA5B77228BC6EF00900729 /* Assets.xcassets */; };
@@ -37,6 +38,8 @@
 /* Begin PBXFileReference section */
 		B5CA8D43228E0A82004097C7 /* PFMoveApplication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFMoveApplication.h; sourceTree = "<group>"; };
 		B5CA8D44228E0A82004097C7 /* PFMoveApplication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFMoveApplication.m; sourceTree = "<group>"; };
+		B5F011012C2C000000000001 /* SNPMenuBarTitleFormatter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SNPMenuBarTitleFormatter.h; sourceTree = "<group>"; };
+		B5F011022C2C000000000001 /* SNPMenuBarTitleFormatter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SNPMenuBarTitleFormatter.m; sourceTree = "<group>"; };
 		B5DA5B6E228BC6EE00900729 /* Spotify Now Playing.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Spotify Now Playing.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5DA5B71228BC6EE00900729 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		B5DA5B72228BC6EE00900729 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -113,6 +116,8 @@
 			children = (
 				B5DA5B71228BC6EE00900729 /* AppDelegate.h */,
 				B5DA5B72228BC6EE00900729 /* AppDelegate.m */,
+				B5F011012C2C000000000001 /* SNPMenuBarTitleFormatter.h */,
+				B5F011022C2C000000000001 /* SNPMenuBarTitleFormatter.m */,
 				B5DA5B74228BC6EE00900729 /* ViewController.h */,
 				B5DA5B75228BC6EE00900729 /* ViewController.m */,
 				B5DA5B77228BC6EF00900729 /* Assets.xcassets */,
@@ -281,6 +286,7 @@
 				B5DA5B76228BC6EE00900729 /* ViewController.m in Sources */,
 				B5DA5B7E228BC6EF00900729 /* main.m in Sources */,
 				B5DA5B73228BC6EE00900729 /* AppDelegate.m in Sources */,
+				B5F011032C2C000000000001 /* SNPMenuBarTitleFormatter.m in Sources */,
 				B5CA8D45228E0A82004097C7 /* PFMoveApplication.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Spotify Now Playing/AppDelegate.m
+++ b/Spotify Now Playing/AppDelegate.m
@@ -29,6 +29,8 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
 @property (nonatomic, strong) NSMenuItem *albumMenuItem;
 @property (nonatomic, strong) NSMenuItem *notificationStateMenuItem;
 @property (nonatomic, strong) NSMenuItem *startAtLoginMenuItem;
+@property (nonatomic, strong) NSTimer *titleRefreshTimer;
+@property (nonatomic) NSTimeInterval currentTrackDuration;
 @property (nonatomic) float panX;
 @property (nonatomic) BOOL playing;
 
@@ -91,7 +93,7 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
     
     // initialize options menu items
     NSMenuItem *menubarFormatMenuItem = [[NSMenuItem alloc] initWithTitle:@"Menubar format..." action:@selector(editMenubarFormat) keyEquivalent:@""];
-    menubarFormatMenuItem.toolTip = @"Customize the menu bar title with {playbackSymbol}, {artist}, {title}, and {album}";
+    menubarFormatMenuItem.toolTip = @"Customize the menu bar title with track and playback time placeholders";
     self.notificationStateMenuItem = [[NSMenuItem alloc] initWithTitle:@"Song notifications" action:@selector(toggleNotifications) keyEquivalent:@""];
     self.notificationStateMenuItem.toolTip = @"Get a notification when a new song comes on";
     self.notificationStateMenuItem.state = [[NSUserDefaults standardUserDefaults] boolForKey:SNPNotificationStatePreferenceKey];
@@ -126,6 +128,7 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
         self.songMenuItem.title = self.currentSongName;
         self.artistMenuItem.title = [[self executeAppleScript:@"get artist of current track"] stringValue];
         self.albumMenuItem.title =[[self executeAppleScript:@"get album of current track"] stringValue];
+        self.currentTrackDuration = [self trackDurationFromSpotify];
         [self updateTitle];
         self.statusItem.button.toolTip = [NSString stringWithFormat:@"%@\n%@\n%@",self.currentSongName,self.artistMenuItem.title,self.albumMenuItem.title];
         [self setImage];
@@ -145,7 +148,9 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
         self.artistMenuItem.title = @"Click here to open Spotify.";
         self.albumMenuItem.title = @"";
         self.playing = NO;
+        self.currentTrackDuration = 0;
         self.statusItem.button.toolTip = @"Spotify Now Playing";
+        [self updateTitleRefreshTimer];
     }
     
     // set up notification center
@@ -166,7 +171,7 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
     NSAlert *alert = [[NSAlert alloc] init];
     {
         [alert setMessageText:@"Welcome to Spotify Now Playing!"];
-        [alert setInformativeText:@"Spotify Now Playing gives you easy access to see what song is playing in Spotify!\n\nHelp:\nClick on SNP up in the menu bar to see information about the song that's currently playing.\nClick and hold to play/pause, and click and drag right/left to skip/go back.\n\nOptions:\nMenubar format: customize the menu bar title with {playbackSymbol}, {artist}, {title}, and {album}.\nSong notifications: get a notification when a new song comes on.\nStart at login: automatically launch SNP when starting up your computer.\n\nEnjoy!\n-Abel John"];
+        [alert setInformativeText:@"Spotify Now Playing gives you easy access to see what song is playing in Spotify!\n\nHelp:\nClick on SNP up in the menu bar to see information about the song that's currently playing.\nClick and hold to play/pause, and click and drag right/left to skip/go back.\n\nOptions:\nMenubar format: customize the menu bar title with {playbackSymbol}, {artist}, {title}, {album}, {position}, {duration}, and {remaining}.\nSong notifications: get a notification when a new song comes on.\nStart at login: automatically launch SNP when starting up your computer.\n\nEnjoy!\n-Abel John"];
         [alert addButtonWithTitle:@"Okay!"];
         [alert setShowsSuppressionButton:YES];
         NSCell *cell = [[alert suppressionButton] cell];
@@ -197,7 +202,9 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
         self.artistMenuItem.title = @"Click here to open Spotify.";
         self.albumMenuItem.title = @"";
         self.playing = NO;
+        self.currentTrackDuration = 0;
         self.statusItem.button.toolTip = @"Spotify Now Playing";
+        [self updateTitleRefreshTimer];
     } else {
         self.playing = [[[aNotification userInfo] objectForKey:@"Player State"] isEqualToString:@"Playing"];
         if (![[[aNotification userInfo] objectForKey:@"Track ID"] isEqualToString:self.trackID]
@@ -208,6 +215,7 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
             self.songMenuItem.title = self.currentSongName;
             self.artistMenuItem.title = [[aNotification userInfo] objectForKey:@"Artist"];
             self.albumMenuItem.title = [[aNotification userInfo] objectForKey:@"Album"];
+            self.currentTrackDuration = [self trackDurationFromSpotify];
             [self updateTitle];
             self.statusItem.button.toolTip = [NSString stringWithFormat:@"%@\n%@\n%@",self.currentSongName,self.artistMenuItem.title,self.albumMenuItem.title];
             [self showNotification];
@@ -227,7 +235,7 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
 {
     NSAlert *alert = [[NSAlert alloc] init];
     [alert setMessageText:@"Menubar Format"];
-    [alert setInformativeText:@"Use {playbackSymbol}, {artist}, {title}, and {album}. Text inside [...] appears only when all placeholders in it have values."];
+    [alert setInformativeText:@"Use {playbackSymbol}, {artist}, {title}, {album}, {position}, {duration}, and {remaining}. Text inside [...] appears only when all placeholders in it have values."];
     [alert addButtonWithTitle:@"Save"];
     [alert addButtonWithTitle:@"Cancel"];
     [alert addButtonWithTitle:@"Restore Defaults"];
@@ -244,6 +252,8 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
     } else if (response == NSAlertThirdButtonReturn) {
         [[NSUserDefaults standardUserDefaults] setObject:SNPDefaultMenubarFormat forKey:SNPMenubarFormatPreferenceKey];
         [self updateTitle];
+    } else {
+        [self updateTitleRefreshTimer];
     }
 }
 
@@ -408,21 +418,86 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
     if ([self.currentSongName length] == 0) {
         self.statusItem.button.title = @"";
         self.statusItem.button.image = self.menubarImage;
+        [self updateTitleRefreshTimer];
         return;
     }
 
-    self.statusItem.button.title = [SNPMenuBarTitleFormatter titleWithFormat:[self menubarFormat]
+    NSString *format = [self menubarFormat];
+    NSString *position = @"";
+    NSString *duration = @"";
+    NSString *remaining = @"";
+    if ([SNPMenuBarTitleFormatter formatUsesPlaybackTime:format]) {
+        NSTimeInterval playbackPosition = [self playbackPositionFromSpotify];
+        position = [self stringFromPlaybackTime:playbackPosition];
+        if (self.currentTrackDuration > 0) {
+            duration = [self stringFromPlaybackTime:self.currentTrackDuration];
+            remaining = [NSString stringWithFormat:@"-%@", [self stringFromPlaybackTime:MAX(self.currentTrackDuration - playbackPosition, 0)]];
+        }
+    }
+
+    self.statusItem.button.title = [SNPMenuBarTitleFormatter titleWithFormat:format
                                                                     songTitle:self.currentSongName
                                                                        artist:self.artistMenuItem.title
                                                                         album:self.albumMenuItem.title
+                                                                     position:position
+                                                                     duration:duration
+                                                                    remaining:remaining
                                                                       playing:self.playing];
     [self preventBlankTitle];
+    [self updateTitleRefreshTimer];
 }
 
 - (NSString *)menubarFormat
 {
     NSString *format = [[NSUserDefaults standardUserDefaults] stringForKey:SNPMenubarFormatPreferenceKey];
     return format ?: SNPDefaultMenubarFormat;
+}
+
+- (void)updateTitleRefreshTimer
+{
+    if (self.playing && [self.currentSongName length] != 0 && [SNPMenuBarTitleFormatter formatUsesPlaybackTime:[self menubarFormat]]) {
+        if (!self.titleRefreshTimer) {
+            self.titleRefreshTimer = [NSTimer scheduledTimerWithTimeInterval:1 target:self selector:@selector(titleRefreshTimerFired:) userInfo:nil repeats:YES];
+        }
+    } else {
+        [self.titleRefreshTimer invalidate];
+        self.titleRefreshTimer = nil;
+    }
+}
+
+- (void)titleRefreshTimerFired:(NSTimer *)timer
+{
+    timer = nil;
+    [self updateTitle];
+}
+
+- (NSTimeInterval)playbackPositionFromSpotify
+{
+    NSString *position = [[self executeAppleScript:@"get player position"] stringValue];
+    return [position doubleValue];
+}
+
+- (NSTimeInterval)trackDurationFromSpotify
+{
+    NSString *duration = [[self executeAppleScript:@"get duration of current track"] stringValue];
+    return [duration doubleValue] / 1000.0;
+}
+
+- (NSString *)stringFromPlaybackTime:(NSTimeInterval)time
+{
+    NSInteger totalSeconds = (NSInteger)time;
+    if (totalSeconds < 0) {
+        totalSeconds = 0;
+    }
+
+    NSInteger hours = totalSeconds / 3600;
+    NSInteger minutes = (totalSeconds / 60) % 60;
+    NSInteger seconds = totalSeconds % 60;
+
+    if (hours > 0) {
+        return [NSString stringWithFormat:@"%ld:%02ld:%02ld", hours, minutes, seconds];
+    }
+    return [NSString stringWithFormat:@"%ld:%02ld", minutes, seconds];
 }
 
 - (void)preventBlankTitle
@@ -443,6 +518,8 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
 
 - (void)quit
 {
+    [self.titleRefreshTimer invalidate];
+    self.titleRefreshTimer = nil;
     [[NSUserNotificationCenter defaultUserNotificationCenter] removeAllDeliveredNotifications];
     [[NSApplication sharedApplication] terminate:self];
 }

--- a/Spotify Now Playing/AppDelegate.m
+++ b/Spotify Now Playing/AppDelegate.m
@@ -370,10 +370,12 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
     NSURLSessionDataTask *task = [session dataTaskWithRequest:urlRequest completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if (error) {
             //NSLog(@"Error,%@", [error localizedDescription]);
-            self.artworkMenuItem.image = nil;
-            self.artworkMenuItem.title = @"Could not load album artwork";
-            self.artworkMenuItem.action = @selector(setImage);
-            self.artworkMenuItem.toolTip = @"Click to try again";
+            dispatch_async(dispatch_get_main_queue(), ^(void) {
+                self.artworkMenuItem.image = nil;
+                self.artworkMenuItem.title = @"Could not load album artwork";
+                self.artworkMenuItem.action = @selector(setImage);
+                self.artworkMenuItem.toolTip = @"Click to try again";
+            });
         } else {
             //NSLog(@"%@", [[NSString alloc] initWithData:data encoding:NSASCIIStringEncoding]);
             NSMutableDictionary *parsedData = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:nil];
@@ -383,25 +385,30 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
             NSURLSessionDataTask *imageTask = [imageSession dataTaskWithRequest:imageUrlRequest completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
                 if (error) {
                     //NSLog(@"Error,%@", [error localizedDescription]);
-                    self.artworkMenuItem.image = nil;
-                    self.artworkMenuItem.title = @"Could not load album artwork";
-                    self.artworkMenuItem.action = @selector(setImage);
-                    self.artworkMenuItem.toolTip = @"Click to try again";
+                    dispatch_async(dispatch_get_main_queue(), ^(void) {
+                        self.artworkMenuItem.image = nil;
+                        self.artworkMenuItem.title = @"Could not load album artwork";
+                        self.artworkMenuItem.action = @selector(setImage);
+                        self.artworkMenuItem.toolTip = @"Click to try again";
+                    });
                 } else {
-                    self.currentAlbumArt = [[NSImage alloc] initWithData:data];
-                    self.currentAlbumArt.size = CGSizeMake(200, 200);
-                    self.artworkMenuItem.image = self.currentAlbumArt;
-                    self.artworkMenuItem.title = @"";
-                    self.artworkMenuItem.action = @selector(launchSpotify);
-                    self.artworkMenuItem.toolTip = nil;
+                    dispatch_async(dispatch_get_main_queue(), ^(void) {
+                        self.currentAlbumArt = [[NSImage alloc] initWithData:data];
+                        self.currentAlbumArt.size = CGSizeMake(200, 200);
+                        self.artworkMenuItem.image = self.currentAlbumArt;
+                        self.artworkMenuItem.title = @"";
+                        self.artworkMenuItem.action = @selector(launchSpotify);
+                        self.artworkMenuItem.toolTip = nil;
+                    });
                 }
             }];
             [imageTask resume];
             // if title was unavailable when song changed, add it now
             if ([self.currentSongName length] == 0) {
-                self.currentSongName = parsedData[@"title"];
+                NSString *parsedTitle = parsedData[@"title"];
                 // make UI changes in main thread
                 dispatch_async(dispatch_get_main_queue(), ^(void) {
+                    self.currentSongName = parsedTitle;
                     [self updateTitle];
                     self.songMenuItem.title = self.currentSongName;
                     self.statusItem.button.toolTip = [NSString stringWithFormat:@"%@\n%@\n%@",self.currentSongName,self.artistMenuItem.title,self.albumMenuItem.title];

--- a/Spotify Now Playing/AppDelegate.m
+++ b/Spotify Now Playing/AppDelegate.m
@@ -12,9 +12,16 @@
 
 static NSString * const SNPNotificationStatePreferenceKey = @"SNPNotificationState";
 static NSString * const SNPMenubarFormatPreferenceKey = @"SNPMenubarFormat";
+static NSString * const SNPRainbowTitleEffectPreferenceKey = @"SNPRainbowTitleEffect";
+static NSString * const SNPRainbowTitleHueStepPreferenceKey = @"SNPRainbowTitleHueStep";
+static NSString * const SNPRainbowTitleSaturationPreferenceKey = @"SNPRainbowTitleSaturation";
 static NSString * const SNPStartAtLoginPreferenceKey = @"SNPStartAtLogin";
 static NSString * const SNPStartupInformationPreferenceKey = @"SNPStartupInformation";
 static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
+static CGFloat const SNPRainbowTitleDefaultHueStep = 0.01;
+static CGFloat const SNPRainbowTitleMinHueStep = 0.001;
+static CGFloat const SNPRainbowTitleMaxHueStep = 0.05;
+static CGFloat const SNPRainbowTitleDefaultSaturation = 0.5;
 
 @interface AppDelegate ()
 
@@ -27,12 +34,18 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
 @property (nonatomic, strong) NSMenuItem *songMenuItem;
 @property (nonatomic, strong) NSMenuItem *artistMenuItem;
 @property (nonatomic, strong) NSMenuItem *albumMenuItem;
+@property (nonatomic, strong) NSMenuItem *rainbowTitleMenuItem;
 @property (nonatomic, strong) NSMenuItem *notificationStateMenuItem;
 @property (nonatomic, strong) NSMenuItem *startAtLoginMenuItem;
 @property (nonatomic, strong) NSTimer *titleRefreshTimer;
+@property (nonatomic, strong) NSTimer *rainbowTitleTimer;
 @property (nonatomic, strong) NSDate *playbackPositionReferenceDate;
+@property (nonatomic, strong) NSString *currentMenubarTitle;
+@property (nonatomic, strong) NSTextField *rainbowHueStepValueLabel;
+@property (nonatomic, strong) NSTextField *rainbowSaturationValueLabel;
 @property (nonatomic) NSTimeInterval currentTrackDuration;
 @property (nonatomic) NSTimeInterval currentPlaybackPosition;
+@property (nonatomic) CGFloat rainbowTitlePhase;
 @property (nonatomic) float panX;
 @property (nonatomic) BOOL playing;
 
@@ -44,7 +57,10 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
     PFMoveToApplicationsFolderIfNecessary();
-    [[NSUserDefaults standardUserDefaults] registerDefaults:@{SNPMenubarFormatPreferenceKey: SNPDefaultMenubarFormat}];
+    [[NSUserDefaults standardUserDefaults] registerDefaults:@{SNPMenubarFormatPreferenceKey: SNPDefaultMenubarFormat,
+                                                              SNPRainbowTitleEffectPreferenceKey: @NO,
+                                                              SNPRainbowTitleHueStepPreferenceKey: @(SNPRainbowTitleDefaultHueStep),
+                                                              SNPRainbowTitleSaturationPreferenceKey: @(SNPRainbowTitleDefaultSaturation)}];
     
     // show welcome screen
     if (![[NSUserDefaults standardUserDefaults] boolForKey:SNPStartupInformationPreferenceKey]) {
@@ -96,6 +112,11 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
     // initialize options menu items
     NSMenuItem *menubarFormatMenuItem = [[NSMenuItem alloc] initWithTitle:@"Menubar format..." action:@selector(editMenubarFormat) keyEquivalent:@""];
     menubarFormatMenuItem.toolTip = @"Customize the menu bar title with track and playback time placeholders";
+    self.rainbowTitleMenuItem = [[NSMenuItem alloc] initWithTitle:@"Rainbow title effect" action:@selector(toggleRainbowTitleEffect) keyEquivalent:@""];
+    self.rainbowTitleMenuItem.toolTip = @"Animate the menu bar title colors while music is playing";
+    self.rainbowTitleMenuItem.state = [[NSUserDefaults standardUserDefaults] boolForKey:SNPRainbowTitleEffectPreferenceKey];
+    NSMenuItem *rainbowTitleSettingsMenuItem = [[NSMenuItem alloc] initWithTitle:@"Rainbow title settings..." action:@selector(editRainbowTitleSettings) keyEquivalent:@""];
+    rainbowTitleSettingsMenuItem.toolTip = @"Adjust rainbow title hue spacing and saturation";
     self.notificationStateMenuItem = [[NSMenuItem alloc] initWithTitle:@"Song notifications" action:@selector(toggleNotifications) keyEquivalent:@""];
     self.notificationStateMenuItem.toolTip = @"Get a notification when a new song comes on";
     self.notificationStateMenuItem.state = [[NSUserDefaults standardUserDefaults] boolForKey:SNPNotificationStatePreferenceKey];
@@ -111,6 +132,8 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
     [mainMenu addItem:[NSMenuItem separatorItem]];
     [optionsMenu setSubmenu:optionsSubmenu];
     [optionsSubmenu addItem:menubarFormatMenuItem];
+    [optionsSubmenu addItem:self.rainbowTitleMenuItem];
+    [optionsSubmenu addItem:rainbowTitleSettingsMenuItem];
     [optionsSubmenu addItem:self.notificationStateMenuItem];
     [optionsSubmenu addItem:self.startAtLoginMenuItem];
     [mainMenu addItem:optionsMenu];
@@ -139,8 +162,6 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
         
     }
     @catch (NSException *e) {
-        self.statusItem.button.title = @"";
-        self.statusItem.button.image = self.menubarImage;
         self.trackID = @"";
         self.currentSongName = @"";
         self.currentAlbumArt = nil;
@@ -154,8 +175,11 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
         self.currentTrackDuration = 0;
         self.currentPlaybackPosition = 0;
         self.playbackPositionReferenceDate = nil;
+        [self setStatusButtonTitle:@""];
+        [self preventBlankTitle];
         self.statusItem.button.toolTip = @"Spotify Now Playing";
         [self updateTitleRefreshTimer];
+        [self updateRainbowTitleTimer];
     }
     
     // set up notification center
@@ -176,7 +200,7 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
     NSAlert *alert = [[NSAlert alloc] init];
     {
         [alert setMessageText:@"Welcome to Spotify Now Playing!"];
-        [alert setInformativeText:@"Spotify Now Playing gives you easy access to see what song is playing in Spotify!\n\nHelp:\nClick on SNP up in the menu bar to see information about the song that's currently playing.\nClick and hold to play/pause, and click and drag right/left to skip/go back.\n\nOptions:\nMenubar format: customize the menu bar title with {playbackSymbol}, {artist}, {title}, {album}, {position}, {duration}, and {remaining}.\nSong notifications: get a notification when a new song comes on.\nStart at login: automatically launch SNP when starting up your computer.\n\nEnjoy!\n-Abel John"];
+        [alert setInformativeText:@"Spotify Now Playing gives you easy access to see what song is playing in Spotify!\n\nHelp:\nClick on SNP up in the menu bar to see information about the song that's currently playing.\nClick and hold to play/pause, and click and drag right/left to skip/go back.\n\nOptions:\nMenubar format: customize the menu bar title with {playbackSymbol}, {artist}, {title}, {album}, {position}, {duration}, and {remaining}.\nRainbow title effect: animate the menu bar title colors while music is playing.\nSong notifications: get a notification when a new song comes on.\nStart at login: automatically launch SNP when starting up your computer.\n\nEnjoy!\n-Abel John"];
         [alert addButtonWithTitle:@"Okay!"];
         [alert setShowsSuppressionButton:YES];
         NSCell *cell = [[alert suppressionButton] cell];
@@ -195,8 +219,6 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
 - (void)playbackStateChanged:(NSNotification *)aNotification
 {
     if ([[[aNotification userInfo] objectForKey:@"Player State"] isEqualToString:@"Stopped"]) {
-        self.statusItem.button.title = @"";
-        self.statusItem.button.image = self.menubarImage;
         self.trackID = @"";
         self.currentSongName = @"";
         self.currentAlbumArt = nil;
@@ -210,8 +232,11 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
         self.currentTrackDuration = 0;
         self.currentPlaybackPosition = 0;
         self.playbackPositionReferenceDate = nil;
+        [self setStatusButtonTitle:@""];
+        [self preventBlankTitle];
         self.statusItem.button.toolTip = @"Spotify Now Playing";
         [self updateTitleRefreshTimer];
+        [self updateRainbowTitleTimer];
     } else {
         self.playing = [[[aNotification userInfo] objectForKey:@"Player State"] isEqualToString:@"Playing"];
         if (![[[aNotification userInfo] objectForKey:@"Track ID"] isEqualToString:self.trackID]
@@ -238,6 +263,81 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
 {
     [[NSUserDefaults standardUserDefaults] setBool:![[NSUserDefaults standardUserDefaults] boolForKey:SNPNotificationStatePreferenceKey] forKey:SNPNotificationStatePreferenceKey];
     self.notificationStateMenuItem.state = [[NSUserDefaults standardUserDefaults] boolForKey:SNPNotificationStatePreferenceKey];
+}
+
+- (void)toggleRainbowTitleEffect
+{
+    BOOL enabled = ![[NSUserDefaults standardUserDefaults] boolForKey:SNPRainbowTitleEffectPreferenceKey];
+    [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:SNPRainbowTitleEffectPreferenceKey];
+    self.rainbowTitleMenuItem.state = enabled;
+    [self updateTitle];
+}
+
+- (void)editRainbowTitleSettings
+{
+    NSAlert *alert = [[NSAlert alloc] init];
+    [alert setMessageText:@"Rainbow Title Settings"];
+    [alert setInformativeText:@"Adjust hue spacing and saturation. Brightness is fixed at 100%."];
+    [alert addButtonWithTitle:@"Save"];
+    [alert addButtonWithTitle:@"Cancel"];
+    [alert addButtonWithTitle:@"Restore Defaults"];
+
+    NSView *settingsView = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 420, 66)];
+    NSTextField *hueLabel = [NSTextField labelWithString:@"Hue spacing"];
+    hueLabel.frame = NSMakeRect(0, 42, 90, 18);
+    NSSlider *hueSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(96, 40, 250, 20)];
+    hueSlider.minValue = SNPRainbowTitleMinHueStep;
+    hueSlider.maxValue = SNPRainbowTitleMaxHueStep;
+    hueSlider.doubleValue = [self rainbowTitleHueStep];
+    hueSlider.continuous = YES;
+    hueSlider.target = self;
+    hueSlider.action = @selector(rainbowSettingsSliderChanged:);
+    hueSlider.tag = 1;
+    self.rainbowHueStepValueLabel = [NSTextField labelWithString:[self stringFromRainbowHueStep:hueSlider.doubleValue]];
+    self.rainbowHueStepValueLabel.frame = NSMakeRect(356, 42, 64, 18);
+
+    NSTextField *saturationLabel = [NSTextField labelWithString:@"Saturation"];
+    saturationLabel.frame = NSMakeRect(0, 12, 90, 18);
+    NSSlider *saturationSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(96, 10, 250, 20)];
+    saturationSlider.minValue = 0;
+    saturationSlider.maxValue = 1;
+    saturationSlider.doubleValue = [self rainbowTitleSaturation];
+    saturationSlider.continuous = YES;
+    saturationSlider.target = self;
+    saturationSlider.action = @selector(rainbowSettingsSliderChanged:);
+    saturationSlider.tag = 2;
+    self.rainbowSaturationValueLabel = [NSTextField labelWithString:[self stringFromRainbowSaturation:saturationSlider.doubleValue]];
+    self.rainbowSaturationValueLabel.frame = NSMakeRect(356, 12, 64, 18);
+
+    [settingsView addSubview:hueLabel];
+    [settingsView addSubview:hueSlider];
+    [settingsView addSubview:self.rainbowHueStepValueLabel];
+    [settingsView addSubview:saturationLabel];
+    [settingsView addSubview:saturationSlider];
+    [settingsView addSubview:self.rainbowSaturationValueLabel];
+    [alert setAccessoryView:settingsView];
+
+    NSModalResponse response = [alert runModal];
+    if (response == NSAlertFirstButtonReturn) {
+        [[NSUserDefaults standardUserDefaults] setDouble:hueSlider.doubleValue forKey:SNPRainbowTitleHueStepPreferenceKey];
+        [[NSUserDefaults standardUserDefaults] setDouble:saturationSlider.doubleValue forKey:SNPRainbowTitleSaturationPreferenceKey];
+        [self updateTitle];
+    } else if (response == NSAlertThirdButtonReturn) {
+        [[NSUserDefaults standardUserDefaults] setDouble:SNPRainbowTitleDefaultHueStep forKey:SNPRainbowTitleHueStepPreferenceKey];
+        [[NSUserDefaults standardUserDefaults] setDouble:SNPRainbowTitleDefaultSaturation forKey:SNPRainbowTitleSaturationPreferenceKey];
+        [self updateTitle];
+    }
+    self.rainbowHueStepValueLabel = nil;
+    self.rainbowSaturationValueLabel = nil;
+}
+
+- (void)rainbowSettingsSliderChanged:(NSSlider *)slider
+{
+    if (slider.tag == 1) {
+        self.rainbowHueStepValueLabel.stringValue = [self stringFromRainbowHueStep:slider.doubleValue];
+    } else if (slider.tag == 2) {
+        self.rainbowSaturationValueLabel.stringValue = [self stringFromRainbowSaturation:slider.doubleValue];
+    }
 }
 
 - (void)editMenubarFormat
@@ -432,9 +532,10 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
 - (void)updateTitle
 {
     if ([self.currentSongName length] == 0) {
-        self.statusItem.button.title = @"";
-        self.statusItem.button.image = self.menubarImage;
+        [self setStatusButtonTitle:@""];
+        [self preventBlankTitle];
         [self updateTitleRefreshTimer];
+        [self updateRainbowTitleTimer];
         return;
     }
 
@@ -451,22 +552,58 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
         }
     }
 
-    self.statusItem.button.title = [SNPMenuBarTitleFormatter titleWithFormat:format
-                                                                    songTitle:self.currentSongName
-                                                                       artist:self.artistMenuItem.title
-                                                                        album:self.albumMenuItem.title
-                                                                     position:position
-                                                                     duration:duration
-                                                                    remaining:remaining
-                                                                      playing:self.playing];
+    NSString *title = [SNPMenuBarTitleFormatter titleWithFormat:format
+                                                      songTitle:self.currentSongName
+                                                         artist:self.artistMenuItem.title
+                                                          album:self.albumMenuItem.title
+                                                       position:position
+                                                       duration:duration
+                                                      remaining:remaining
+                                                        playing:self.playing];
+    [self setStatusButtonTitle:title];
     [self preventBlankTitle];
     [self updateTitleRefreshTimer];
+    [self updateRainbowTitleTimer];
 }
 
 - (NSString *)menubarFormat
 {
     NSString *format = [[NSUserDefaults standardUserDefaults] stringForKey:SNPMenubarFormatPreferenceKey];
     return format ?: SNPDefaultMenubarFormat;
+}
+
+- (BOOL)rainbowTitleEffectEnabled
+{
+    return [[NSUserDefaults standardUserDefaults] boolForKey:SNPRainbowTitleEffectPreferenceKey];
+}
+
+- (CGFloat)rainbowTitleHueStep
+{
+    return [self clampedRainbowValue:[[NSUserDefaults standardUserDefaults] doubleForKey:SNPRainbowTitleHueStepPreferenceKey]
+                             minimum:SNPRainbowTitleMinHueStep
+                             maximum:SNPRainbowTitleMaxHueStep];
+}
+
+- (CGFloat)rainbowTitleSaturation
+{
+    return [self clampedRainbowValue:[[NSUserDefaults standardUserDefaults] doubleForKey:SNPRainbowTitleSaturationPreferenceKey]
+                             minimum:0
+                             maximum:1];
+}
+
+- (CGFloat)clampedRainbowValue:(CGFloat)value minimum:(CGFloat)minimum maximum:(CGFloat)maximum
+{
+    return MIN(MAX(value, minimum), maximum);
+}
+
+- (NSString *)stringFromRainbowHueStep:(CGFloat)hueStep
+{
+    return [NSString stringWithFormat:@"%.3f", hueStep];
+}
+
+- (NSString *)stringFromRainbowSaturation:(CGFloat)saturation
+{
+    return [NSString stringWithFormat:@"%.0f%%", saturation * 100];
 }
 
 - (void)updateTitleRefreshTimer
@@ -485,6 +622,81 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
 {
     timer = nil;
     [self updateTitle];
+}
+
+- (void)setStatusButtonTitle:(NSString *)title
+{
+    self.currentMenubarTitle = title ?: @"";
+    if ([self shouldShowRainbowTitle]) {
+        [self applyRainbowTitle];
+    } else {
+        self.statusItem.button.attributedTitle = [[NSAttributedString alloc] initWithString:@""];
+        self.statusItem.button.title = self.currentMenubarTitle;
+    }
+}
+
+- (void)updateRainbowTitleTimer
+{
+    if ([self shouldShowRainbowTitle]) {
+        if (!self.rainbowTitleTimer) {
+            self.rainbowTitleTimer = [NSTimer scheduledTimerWithTimeInterval:0.12 target:self selector:@selector(rainbowTitleTimerFired:) userInfo:nil repeats:YES];
+        }
+    } else {
+        [self.rainbowTitleTimer invalidate];
+        self.rainbowTitleTimer = nil;
+        self.statusItem.button.attributedTitle = [[NSAttributedString alloc] initWithString:@""];
+        self.statusItem.button.title = self.currentMenubarTitle ?: @"";
+    }
+}
+
+- (void)rainbowTitleTimerFired:(NSTimer *)timer
+{
+    timer = nil;
+    self.rainbowTitlePhase += 0.025;
+    if (self.rainbowTitlePhase >= 1.0) {
+        self.rainbowTitlePhase -= 1.0;
+    }
+
+    if ([self shouldShowRainbowTitle]) {
+        [self applyRainbowTitle];
+    } else {
+        [self updateRainbowTitleTimer];
+    }
+}
+
+- (BOOL)shouldShowRainbowTitle
+{
+    return [self rainbowTitleEffectEnabled] && self.playing && [self.currentMenubarTitle length] != 0;
+}
+
+- (void)applyRainbowTitle
+{
+    NSString *title = self.currentMenubarTitle ?: @"";
+    NSMutableAttributedString *attributedTitle = [[NSMutableAttributedString alloc] initWithString:title];
+    NSFont *font = self.statusItem.button.font ?: [NSFont systemFontOfSize:[NSFont systemFontSize]];
+    [attributedTitle addAttribute:NSFontAttributeName value:font range:NSMakeRange(0, [title length])];
+
+    CGFloat hueStep = [self rainbowTitleHueStep];
+    CGFloat saturation = [self rainbowTitleSaturation];
+    __block NSUInteger characterIndex = 0;
+    [title enumerateSubstringsInRange:NSMakeRange(0, [title length])
+                              options:NSStringEnumerationByComposedCharacterSequences
+                           usingBlock:^(NSString *substring, NSRange substringRange, NSRange enclosingRange, BOOL *stop) {
+        (void)substring;
+        (void)enclosingRange;
+        (void)stop;
+        CGFloat hue = (characterIndex * hueStep) - self.rainbowTitlePhase;
+        while (hue < 0) {
+            hue += 1.0;
+        }
+        while (hue >= 1.0) {
+            hue -= 1.0;
+        }
+        NSColor *color = [NSColor colorWithCalibratedHue:hue saturation:saturation brightness:1.0 alpha:1.0];
+        [attributedTitle addAttribute:NSForegroundColorAttributeName value:color range:substringRange];
+        characterIndex++;
+    }];
+    self.statusItem.button.attributedTitle = attributedTitle;
 }
 
 - (void)refreshPlaybackPositionFromSpotify
@@ -537,7 +749,7 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
 
 - (void)preventBlankTitle
 {
-    if ([self.statusItem.button.title length] != 0) {
+    if ([self.currentMenubarTitle length] != 0) {
         self.statusItem.button.image = nil;
     } else {
         // if the menubar has no text then display the icon so the user can see where the app is
@@ -555,6 +767,8 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
 {
     [self.titleRefreshTimer invalidate];
     self.titleRefreshTimer = nil;
+    [self.rainbowTitleTimer invalidate];
+    self.rainbowTitleTimer = nil;
     [[NSUserNotificationCenter defaultUserNotificationCenter] removeAllDeliveredNotifications];
     [[NSApplication sharedApplication] terminate:self];
 }

--- a/Spotify Now Playing/AppDelegate.m
+++ b/Spotify Now Playing/AppDelegate.m
@@ -22,6 +22,7 @@ static CGFloat const SNPRainbowTitleDefaultHueStep = 0.01;
 static CGFloat const SNPRainbowTitleMinHueStep = 0.001;
 static CGFloat const SNPRainbowTitleMaxHueStep = 0.05;
 static CGFloat const SNPRainbowTitleDefaultSaturation = 0.5;
+static NSTimeInterval const SNPPlaybackPositionSyncInterval = 5.0;
 
 @interface AppDelegate ()
 
@@ -40,6 +41,7 @@ static CGFloat const SNPRainbowTitleDefaultSaturation = 0.5;
 @property (nonatomic, strong) NSTimer *titleRefreshTimer;
 @property (nonatomic, strong) NSTimer *rainbowTitleTimer;
 @property (nonatomic, strong) NSDate *playbackPositionReferenceDate;
+@property (nonatomic, strong) NSDate *lastPlaybackPositionSyncDate;
 @property (nonatomic, strong) NSString *currentMenubarTitle;
 @property (nonatomic, strong) NSTextField *rainbowHueStepValueLabel;
 @property (nonatomic, strong) NSTextField *rainbowSaturationValueLabel;
@@ -175,6 +177,7 @@ static CGFloat const SNPRainbowTitleDefaultSaturation = 0.5;
         self.currentTrackDuration = 0;
         self.currentPlaybackPosition = 0;
         self.playbackPositionReferenceDate = nil;
+        self.lastPlaybackPositionSyncDate = nil;
         [self setStatusButtonTitle:@""];
         [self preventBlankTitle];
         self.statusItem.button.toolTip = @"Spotify Now Playing";
@@ -232,6 +235,7 @@ static CGFloat const SNPRainbowTitleDefaultSaturation = 0.5;
         self.currentTrackDuration = 0;
         self.currentPlaybackPosition = 0;
         self.playbackPositionReferenceDate = nil;
+        self.lastPlaybackPositionSyncDate = nil;
         [self setStatusButtonTitle:@""];
         [self preventBlankTitle];
         self.statusItem.button.toolTip = @"Spotify Now Playing";
@@ -532,6 +536,7 @@ static CGFloat const SNPRainbowTitleDefaultSaturation = 0.5;
 - (void)updateTitle
 {
     if ([self.currentSongName length] == 0) {
+        self.lastPlaybackPositionSyncDate = nil;
         [self setStatusButtonTitle:@""];
         [self preventBlankTitle];
         [self updateTitleRefreshTimer];
@@ -608,7 +613,7 @@ static CGFloat const SNPRainbowTitleDefaultSaturation = 0.5;
 
 - (void)updateTitleRefreshTimer
 {
-    if (self.playing && [self.currentSongName length] != 0 && [SNPMenuBarTitleFormatter formatUsesPlaybackTime:[self menubarFormat]]) {
+    if ([self.currentSongName length] != 0 && [SNPMenuBarTitleFormatter formatUsesPlaybackTime:[self menubarFormat]]) {
         if (!self.titleRefreshTimer) {
             self.titleRefreshTimer = [NSTimer scheduledTimerWithTimeInterval:1 target:self selector:@selector(titleRefreshTimerFired:) userInfo:nil repeats:YES];
         }
@@ -621,6 +626,7 @@ static CGFloat const SNPRainbowTitleDefaultSaturation = 0.5;
 - (void)titleRefreshTimerFired:(NSTimer *)timer
 {
     timer = nil;
+    [self refreshPlaybackPositionFromSpotifyIfNeeded];
     [self updateTitle];
 }
 
@@ -701,8 +707,26 @@ static CGFloat const SNPRainbowTitleDefaultSaturation = 0.5;
 
 - (void)refreshPlaybackPositionFromSpotify
 {
+    NSDate *now = [NSDate date];
     self.currentPlaybackPosition = [self playbackPositionFromSpotify];
-    self.playbackPositionReferenceDate = [NSDate date];
+    self.playbackPositionReferenceDate = now;
+    self.lastPlaybackPositionSyncDate = now;
+}
+
+- (void)refreshPlaybackPositionFromSpotifyIfNeeded
+{
+    if ([self.currentSongName length] == 0 || ![SNPMenuBarTitleFormatter formatUsesPlaybackTime:[self menubarFormat]]) {
+        return;
+    }
+
+    NSDate *now = [NSDate date];
+    if (self.lastPlaybackPositionSyncDate && [now timeIntervalSinceDate:self.lastPlaybackPositionSyncDate] < SNPPlaybackPositionSyncInterval) {
+        return;
+    }
+
+    self.currentPlaybackPosition = [self playbackPositionFromSpotify];
+    self.playbackPositionReferenceDate = now;
+    self.lastPlaybackPositionSyncDate = now;
 }
 
 - (NSTimeInterval)estimatedPlaybackPosition

--- a/Spotify Now Playing/AppDelegate.m
+++ b/Spotify Now Playing/AppDelegate.m
@@ -8,10 +8,10 @@
 
 #import "AppDelegate.h"
 #import "PFMoveApplication.h"
+#import "SNPMenuBarTitleFormatter.h"
 
-static NSString * const SNPPlayerStatePreferenceKey = @"SNPPlayerState";
 static NSString * const SNPNotificationStatePreferenceKey = @"SNPNotificationState";
-static NSString * const SNPMenuIconPreferenceKey = @"SNPMenuIcon";
+static NSString * const SNPMenubarFormatPreferenceKey = @"SNPMenubarFormat";
 static NSString * const SNPStartAtLoginPreferenceKey = @"SNPStartAtLogin";
 static NSString * const SNPStartupInformationPreferenceKey = @"SNPStartupInformation";
 static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
@@ -27,9 +27,7 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
 @property (nonatomic, strong) NSMenuItem *songMenuItem;
 @property (nonatomic, strong) NSMenuItem *artistMenuItem;
 @property (nonatomic, strong) NSMenuItem *albumMenuItem;
-@property (nonatomic, strong) NSMenuItem *playerStateMenuItem;
 @property (nonatomic, strong) NSMenuItem *notificationStateMenuItem;
-@property (nonatomic, strong) NSMenuItem *menuIconMenuItem;
 @property (nonatomic, strong) NSMenuItem *startAtLoginMenuItem;
 @property (nonatomic) float panX;
 @property (nonatomic) BOOL playing;
@@ -42,6 +40,7 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
     PFMoveToApplicationsFolderIfNecessary();
+    [[NSUserDefaults standardUserDefaults] registerDefaults:@{SNPMenubarFormatPreferenceKey: SNPDefaultMenubarFormat}];
     
     // show welcome screen
     if (![[NSUserDefaults standardUserDefaults] boolForKey:SNPStartupInformationPreferenceKey]) {
@@ -91,15 +90,11 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
     self.albumMenuItem = [[NSMenuItem alloc] initWithTitle:@"" action:@selector(launchSpotify) keyEquivalent:@""];
     
     // initialize options menu items
-    self.playerStateMenuItem = [[NSMenuItem alloc] initWithTitle:@"View play icon in menubar" action:[[NSUserDefaults standardUserDefaults] boolForKey:SNPMenuIconPreferenceKey]?nil:@selector(togglePlayerState) keyEquivalent:@""];
-    self.playerStateMenuItem.toolTip = @"Show a play icon in the menu bar when song is playing";
-    self.playerStateMenuItem.state = [[NSUserDefaults standardUserDefaults] boolForKey:SNPPlayerStatePreferenceKey];
+    NSMenuItem *menubarFormatMenuItem = [[NSMenuItem alloc] initWithTitle:@"Menubar format..." action:@selector(editMenubarFormat) keyEquivalent:@""];
+    menubarFormatMenuItem.toolTip = @"Customize the menu bar title with {playbackSymbol}, {artist}, {title}, and {album}";
     self.notificationStateMenuItem = [[NSMenuItem alloc] initWithTitle:@"Song notifications" action:@selector(toggleNotifications) keyEquivalent:@""];
     self.notificationStateMenuItem.toolTip = @"Get a notification when a new song comes on";
     self.notificationStateMenuItem.state = [[NSUserDefaults standardUserDefaults] boolForKey:SNPNotificationStatePreferenceKey];
-    self.menuIconMenuItem = [[NSMenuItem alloc] initWithTitle:@"Hide text in menubar" action:@selector(toggleMenuIcon) keyEquivalent:@""];
-    self.menuIconMenuItem.toolTip = @"Replaces song title with an icon to save space in the menu bar";
-    self.menuIconMenuItem.state = [[NSUserDefaults standardUserDefaults] boolForKey:SNPMenuIconPreferenceKey];
     self.startAtLoginMenuItem = [[NSMenuItem alloc] initWithTitle:@"Start at login" action:@selector(toggleStartAtLogin) keyEquivalent:@""];
     self.startAtLoginMenuItem.toolTip = @"Automatically launch SNP when starting up your computer";
     self.startAtLoginMenuItem.state = [[NSUserDefaults standardUserDefaults] boolForKey:SNPStartAtLoginPreferenceKey];
@@ -111,9 +106,8 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
     [mainMenu addItem:self.albumMenuItem];
     [mainMenu addItem:[NSMenuItem separatorItem]];
     [optionsMenu setSubmenu:optionsSubmenu];
-    [optionsSubmenu addItem:self.playerStateMenuItem];
+    [optionsSubmenu addItem:menubarFormatMenuItem];
     [optionsSubmenu addItem:self.notificationStateMenuItem];
-    [optionsSubmenu addItem:self.menuIconMenuItem];
     [optionsSubmenu addItem:self.startAtLoginMenuItem];
     [mainMenu addItem:optionsMenu];
     [mainMenu addItemWithTitle:@"Help" action:@selector(helpDialog) keyEquivalent:@""];
@@ -129,10 +123,10 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
         self.trackID = [[NSString alloc] initWithString:[[self executeAppleScript:@"get id of current track"] stringValue]];
         self.playing = [[[self executeAppleScript:@"get player state"] stringValue] isEqualToString:@"kPSP"];
         self.currentSongName = [[NSString alloc] initWithString:[[self executeAppleScript:@"get name of current track"] stringValue]];
-        [self updateTitle];
         self.songMenuItem.title = self.currentSongName;
         self.artistMenuItem.title = [[self executeAppleScript:@"get artist of current track"] stringValue];
         self.albumMenuItem.title =[[self executeAppleScript:@"get album of current track"] stringValue];
+        [self updateTitle];
         self.statusItem.button.toolTip = [NSString stringWithFormat:@"%@\n%@\n%@",self.currentSongName,self.artistMenuItem.title,self.albumMenuItem.title];
         [self setImage];
         [self showNotification];
@@ -172,7 +166,7 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
     NSAlert *alert = [[NSAlert alloc] init];
     {
         [alert setMessageText:@"Welcome to Spotify Now Playing!"];
-        [alert setInformativeText:@"Spotify Now Playing gives you easy access to see what song is playing in Spotify!\n\nHelp:\nClick on SNP up in the menu bar to see information about the song that's currently playing.\nClick and hold to play/pause, and click and drag right/left to skip/go back.\n\nOptions:\nView play icon in menubar: show a play icon in the menu bar when song is playing.\nSong notifications: get a notification when a new song comes on.\nHide text in menu bar: replaces song title with an icon to save space in the menu bar.\nStart at login: automatically launch SNP when starting up your computer.\n\nEnjoy!\n-Abel John"];
+        [alert setInformativeText:@"Spotify Now Playing gives you easy access to see what song is playing in Spotify!\n\nHelp:\nClick on SNP up in the menu bar to see information about the song that's currently playing.\nClick and hold to play/pause, and click and drag right/left to skip/go back.\n\nOptions:\nMenubar format: customize the menu bar title with {playbackSymbol}, {artist}, {title}, and {album}.\nSong notifications: get a notification when a new song comes on.\nStart at login: automatically launch SNP when starting up your computer.\n\nEnjoy!\n-Abel John"];
         [alert addButtonWithTitle:@"Okay!"];
         [alert setShowsSuppressionButton:YES];
         NSCell *cell = [[alert suppressionButton] cell];
@@ -211,28 +205,15 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
             self.trackID = [[aNotification userInfo] objectForKey:@"Track ID"];
             [self setImage];
             self.currentSongName = [[aNotification userInfo] objectForKey:@"Name"];
-            [self updateTitle];
             self.songMenuItem.title = self.currentSongName;
             self.artistMenuItem.title = [[aNotification userInfo] objectForKey:@"Artist"];
             self.albumMenuItem.title = [[aNotification userInfo] objectForKey:@"Album"];
+            [self updateTitle];
             self.statusItem.button.toolTip = [NSString stringWithFormat:@"%@\n%@\n%@",self.currentSongName,self.artistMenuItem.title,self.albumMenuItem.title];
             [self showNotification];
         } else {
             [self updateTitle];
         }
-    }
-}
-
-- (void)togglePlayerState
-{
-    [[NSUserDefaults standardUserDefaults] setBool:![[NSUserDefaults standardUserDefaults] boolForKey:SNPPlayerStatePreferenceKey] forKey:SNPPlayerStatePreferenceKey];
-    self.playerStateMenuItem.state = [[NSUserDefaults standardUserDefaults] boolForKey:SNPPlayerStatePreferenceKey];
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:SNPPlayerStatePreferenceKey] && self.playing) {
-        self.statusItem.button.title = [NSString stringWithFormat:@"%@ ►", self.statusItem.button.title];
-        self.statusItem.button.image = nil;
-    } else if (![[NSUserDefaults standardUserDefaults] boolForKey:SNPPlayerStatePreferenceKey] && self.playing) {
-        self.statusItem.button.title = [self shortenSongName];
-        [self preventBlankTitle];
     }
 }
 
@@ -242,18 +223,27 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
     self.notificationStateMenuItem.state = [[NSUserDefaults standardUserDefaults] boolForKey:SNPNotificationStatePreferenceKey];
 }
 
-- (void)toggleMenuIcon
+- (void)editMenubarFormat
 {
-    [[NSUserDefaults standardUserDefaults] setBool:![[NSUserDefaults standardUserDefaults] boolForKey:SNPMenuIconPreferenceKey] forKey:SNPMenuIconPreferenceKey];
-    self.menuIconMenuItem.state = [[NSUserDefaults standardUserDefaults] boolForKey:SNPMenuIconPreferenceKey];
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:SNPMenuIconPreferenceKey]) {
-        self.playerStateMenuItem.action = nil;
-        self.statusItem.button.title = @"";
-        self.statusItem.button.image = self.menubarImage;
-    } else {
-        self.playerStateMenuItem.action = @selector(togglePlayerState);
-        self.statusItem.button.title = ([[NSUserDefaults standardUserDefaults] boolForKey:SNPPlayerStatePreferenceKey] && self.playing)?[NSString stringWithFormat:@"%@ ►",[self shortenSongName]]:[self shortenSongName];
-        [self preventBlankTitle];
+    NSAlert *alert = [[NSAlert alloc] init];
+    [alert setMessageText:@"Menubar Format"];
+    [alert setInformativeText:@"Use {playbackSymbol}, {artist}, {title}, and {album}. Text inside [...] appears only when all placeholders in it have values."];
+    [alert addButtonWithTitle:@"Save"];
+    [alert addButtonWithTitle:@"Cancel"];
+    [alert addButtonWithTitle:@"Restore Defaults"];
+
+    NSTextField *formatField = [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 420, 24)];
+    formatField.stringValue = [self menubarFormat];
+    formatField.placeholderString = SNPDefaultMenubarFormat;
+    [alert setAccessoryView:formatField];
+
+    NSModalResponse response = [alert runModal];
+    if (response == NSAlertFirstButtonReturn) {
+        [[NSUserDefaults standardUserDefaults] setObject:formatField.stringValue forKey:SNPMenubarFormatPreferenceKey];
+        [self updateTitle];
+    } else if (response == NSAlertThirdButtonReturn) {
+        [[NSUserDefaults standardUserDefaults] setObject:SNPDefaultMenubarFormat forKey:SNPMenubarFormatPreferenceKey];
+        [self updateTitle];
     }
 }
 
@@ -333,19 +323,6 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
         [[NSWorkspace sharedWorkspace] launchApplication:@"Spotify.app"];
     }
     
-}
-
-- (NSString *)shortenSongName
-{
-    NSString *nameText = [NSString stringWithString:self.currentSongName];
-    for (NSUInteger i = 1; i<[nameText length]; i++) {
-        unichar letter = [nameText characterAtIndex:i];
-        if ((letter == '-' || letter == '(' || letter == '[' || letter == '/') && [nameText characterAtIndex:(i-1)] == ' ') {
-            nameText = [nameText substringToIndex:i];
-            break;
-        }
-    }
-    return nameText;
 }
 
 - (void)launchSpotify
@@ -428,13 +405,24 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
 
 - (void)updateTitle
 {
-    if (![[NSUserDefaults standardUserDefaults] boolForKey:SNPMenuIconPreferenceKey]) {
-        self.statusItem.button.title = ([[NSUserDefaults standardUserDefaults] boolForKey:SNPPlayerStatePreferenceKey] && self.playing)?[NSString stringWithFormat:@"%@ ►",[self shortenSongName]]:[self shortenSongName];
-        [self preventBlankTitle];
-    } else {
+    if ([self.currentSongName length] == 0) {
         self.statusItem.button.title = @"";
         self.statusItem.button.image = self.menubarImage;
+        return;
     }
+
+    self.statusItem.button.title = [SNPMenuBarTitleFormatter titleWithFormat:[self menubarFormat]
+                                                                    songTitle:self.currentSongName
+                                                                       artist:self.artistMenuItem.title
+                                                                        album:self.albumMenuItem.title
+                                                                      playing:self.playing];
+    [self preventBlankTitle];
+}
+
+- (NSString *)menubarFormat
+{
+    NSString *format = [[NSUserDefaults standardUserDefaults] stringForKey:SNPMenubarFormatPreferenceKey];
+    return format ?: SNPDefaultMenubarFormat;
 }
 
 - (void)preventBlankTitle

--- a/Spotify Now Playing/AppDelegate.m
+++ b/Spotify Now Playing/AppDelegate.m
@@ -30,7 +30,9 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
 @property (nonatomic, strong) NSMenuItem *notificationStateMenuItem;
 @property (nonatomic, strong) NSMenuItem *startAtLoginMenuItem;
 @property (nonatomic, strong) NSTimer *titleRefreshTimer;
+@property (nonatomic, strong) NSDate *playbackPositionReferenceDate;
 @property (nonatomic) NSTimeInterval currentTrackDuration;
+@property (nonatomic) NSTimeInterval currentPlaybackPosition;
 @property (nonatomic) float panX;
 @property (nonatomic) BOOL playing;
 
@@ -129,6 +131,7 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
         self.artistMenuItem.title = [[self executeAppleScript:@"get artist of current track"] stringValue];
         self.albumMenuItem.title =[[self executeAppleScript:@"get album of current track"] stringValue];
         self.currentTrackDuration = [self trackDurationFromSpotify];
+        [self refreshPlaybackPositionFromSpotify];
         [self updateTitle];
         self.statusItem.button.toolTip = [NSString stringWithFormat:@"%@\n%@\n%@",self.currentSongName,self.artistMenuItem.title,self.albumMenuItem.title];
         [self setImage];
@@ -149,6 +152,8 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
         self.albumMenuItem.title = @"";
         self.playing = NO;
         self.currentTrackDuration = 0;
+        self.currentPlaybackPosition = 0;
+        self.playbackPositionReferenceDate = nil;
         self.statusItem.button.toolTip = @"Spotify Now Playing";
         [self updateTitleRefreshTimer];
     }
@@ -203,6 +208,8 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
         self.albumMenuItem.title = @"";
         self.playing = NO;
         self.currentTrackDuration = 0;
+        self.currentPlaybackPosition = 0;
+        self.playbackPositionReferenceDate = nil;
         self.statusItem.button.toolTip = @"Spotify Now Playing";
         [self updateTitleRefreshTimer];
     } else {
@@ -216,10 +223,12 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
             self.artistMenuItem.title = [[aNotification userInfo] objectForKey:@"Artist"];
             self.albumMenuItem.title = [[aNotification userInfo] objectForKey:@"Album"];
             self.currentTrackDuration = [self trackDurationFromSpotify];
+            [self refreshPlaybackPositionFromSpotify];
             [self updateTitle];
             self.statusItem.button.toolTip = [NSString stringWithFormat:@"%@\n%@\n%@",self.currentSongName,self.artistMenuItem.title,self.albumMenuItem.title];
             [self showNotification];
         } else {
+            [self refreshPlaybackPositionFromSpotify];
             [self updateTitle];
         }
     }
@@ -434,7 +443,7 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
     NSString *duration = @"";
     NSString *remaining = @"";
     if ([SNPMenuBarTitleFormatter formatUsesPlaybackTime:format]) {
-        NSTimeInterval playbackPosition = [self playbackPositionFromSpotify];
+        NSTimeInterval playbackPosition = [self estimatedPlaybackPosition];
         position = [self stringFromPlaybackTime:playbackPosition];
         if (self.currentTrackDuration > 0) {
             duration = [self stringFromPlaybackTime:self.currentTrackDuration];
@@ -476,6 +485,25 @@ static NSString * const SNPFirstLoginKey = @"SNPFirstLogin";
 {
     timer = nil;
     [self updateTitle];
+}
+
+- (void)refreshPlaybackPositionFromSpotify
+{
+    self.currentPlaybackPosition = [self playbackPositionFromSpotify];
+    self.playbackPositionReferenceDate = [NSDate date];
+}
+
+- (NSTimeInterval)estimatedPlaybackPosition
+{
+    NSTimeInterval playbackPosition = self.currentPlaybackPosition;
+    if (self.playing && self.playbackPositionReferenceDate) {
+        playbackPosition += [[NSDate date] timeIntervalSinceDate:self.playbackPositionReferenceDate];
+    }
+    playbackPosition = MAX(playbackPosition, 0);
+    if (self.currentTrackDuration > 0) {
+        playbackPosition = MIN(playbackPosition, self.currentTrackDuration);
+    }
+    return playbackPosition;
 }
 
 - (NSTimeInterval)playbackPositionFromSpotify

--- a/Spotify Now Playing/SNPMenuBarTitleFormatter.h
+++ b/Spotify Now Playing/SNPMenuBarTitleFormatter.h
@@ -10,4 +10,15 @@ extern NSString * const SNPDefaultMenubarFormat;
                         album:(NSString *)album
                       playing:(BOOL)playing;
 
++ (NSString *)titleWithFormat:(NSString *)format
+                    songTitle:(NSString *)songTitle
+                       artist:(NSString *)artist
+                        album:(NSString *)album
+                     position:(NSString *)position
+                     duration:(NSString *)duration
+                    remaining:(NSString *)remaining
+                      playing:(BOOL)playing;
+
++ (BOOL)formatUsesPlaybackTime:(NSString *)format;
+
 @end

--- a/Spotify Now Playing/SNPMenuBarTitleFormatter.h
+++ b/Spotify Now Playing/SNPMenuBarTitleFormatter.h
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+
+extern NSString * const SNPDefaultMenubarFormat;
+
+@interface SNPMenuBarTitleFormatter : NSObject
+
++ (NSString *)titleWithFormat:(NSString *)format
+                    songTitle:(NSString *)songTitle
+                       artist:(NSString *)artist
+                        album:(NSString *)album
+                      playing:(BOOL)playing;
+
+@end

--- a/Spotify Now Playing/SNPMenuBarTitleFormatter.m
+++ b/Spotify Now Playing/SNPMenuBarTitleFormatter.m
@@ -1,0 +1,95 @@
+#import "SNPMenuBarTitleFormatter.h"
+
+NSString * const SNPDefaultMenubarFormat = @"{playbackSymbol} [{artist} - ]{title}";
+
+@implementation SNPMenuBarTitleFormatter
+
++ (NSString *)titleWithFormat:(NSString *)format
+                    songTitle:(NSString *)songTitle
+                       artist:(NSString *)artist
+                        album:(NSString *)album
+                      playing:(BOOL)playing
+{
+    NSDictionary<NSString *, NSString *> *values = @{
+        @"title": songTitle ?: @"",
+        @"artist": artist ?: @"",
+        @"album": album ?: @"",
+        @"playbackSymbol": playing ? @"▶" : @"⏸"
+    };
+    NSString *formatString = format ?: SNPDefaultMenubarFormat;
+    NSString *optionalText = [self stringByRenderingOptionalSegmentsInString:formatString values:values];
+    NSString *title = [self stringByReplacingPlaceholdersInString:optionalText values:values];
+    return [title stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+}
+
++ (NSString *)stringByRenderingOptionalSegmentsInString:(NSString *)string values:(NSDictionary<NSString *, NSString *> *)values
+{
+    NSMutableString *result = [NSMutableString string];
+    NSUInteger index = 0;
+
+    while (index < string.length) {
+        NSRange searchRange = NSMakeRange(index, string.length - index);
+        NSRange openRange = [string rangeOfString:@"[" options:0 range:searchRange];
+        if (openRange.location == NSNotFound) {
+            [result appendString:[string substringFromIndex:index]];
+            break;
+        }
+
+        [result appendString:[string substringWithRange:NSMakeRange(index, openRange.location - index)]];
+
+        NSRange closeSearchRange = NSMakeRange(openRange.location + 1, string.length - openRange.location - 1);
+        NSRange closeRange = [string rangeOfString:@"]" options:0 range:closeSearchRange];
+        if (closeRange.location == NSNotFound) {
+            [result appendString:[string substringFromIndex:openRange.location]];
+            break;
+        }
+
+        NSString *segment = [string substringWithRange:NSMakeRange(openRange.location + 1, closeRange.location - openRange.location - 1)];
+        if ([self optionalSegmentHasValues:segment values:values]) {
+            [result appendString:segment];
+        }
+        index = closeRange.location + 1;
+    }
+
+    return result;
+}
+
++ (BOOL)optionalSegmentHasValues:(NSString *)segment values:(NSDictionary<NSString *, NSString *> *)values
+{
+    NSArray<NSTextCheckingResult *> *matches = [self placeholderMatchesInString:segment];
+    for (NSTextCheckingResult *match in matches) {
+        NSString *key = [segment substringWithRange:[match rangeAtIndex:1]];
+        NSString *value = values[key] ?: @"";
+        if ([[value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] length] == 0) {
+            return NO;
+        }
+    }
+    return YES;
+}
+
++ (NSString *)stringByReplacingPlaceholdersInString:(NSString *)string values:(NSDictionary<NSString *, NSString *> *)values
+{
+    NSMutableString *result = [string mutableCopy];
+    NSArray<NSTextCheckingResult *> *matches = [self placeholderMatchesInString:string];
+
+    for (NSTextCheckingResult *match in [matches reverseObjectEnumerator]) {
+        NSString *key = [string substringWithRange:[match rangeAtIndex:1]];
+        NSString *value = values[key] ?: @"";
+        [result replaceCharactersInRange:match.range withString:value];
+    }
+
+    return result;
+}
+
++ (NSArray<NSTextCheckingResult *> *)placeholderMatchesInString:(NSString *)string
+{
+    static NSRegularExpression *placeholderExpression = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        placeholderExpression = [NSRegularExpression regularExpressionWithPattern:@"\\{([^{}]+)\\}" options:0 error:nil];
+    });
+
+    return [placeholderExpression matchesInString:string options:0 range:NSMakeRange(0, string.length)];
+}
+
+@end

--- a/Spotify Now Playing/SNPMenuBarTitleFormatter.m
+++ b/Spotify Now Playing/SNPMenuBarTitleFormatter.m
@@ -10,16 +10,44 @@ NSString * const SNPDefaultMenubarFormat = @"{playbackSymbol} [{artist} - ]{titl
                         album:(NSString *)album
                       playing:(BOOL)playing
 {
+    return [self titleWithFormat:format
+                       songTitle:songTitle
+                          artist:artist
+                           album:album
+                        position:@""
+                        duration:@""
+                       remaining:@""
+                         playing:playing];
+}
+
++ (NSString *)titleWithFormat:(NSString *)format
+                    songTitle:(NSString *)songTitle
+                       artist:(NSString *)artist
+                        album:(NSString *)album
+                     position:(NSString *)position
+                     duration:(NSString *)duration
+                    remaining:(NSString *)remaining
+                      playing:(BOOL)playing
+{
     NSDictionary<NSString *, NSString *> *values = @{
         @"title": songTitle ?: @"",
         @"artist": artist ?: @"",
         @"album": album ?: @"",
+        @"position": position ?: @"",
+        @"duration": duration ?: @"",
+        @"remaining": remaining ?: @"",
         @"playbackSymbol": playing ? @"▶" : @"⏸"
     };
     NSString *formatString = format ?: SNPDefaultMenubarFormat;
     NSString *optionalText = [self stringByRenderingOptionalSegmentsInString:formatString values:values];
     NSString *title = [self stringByReplacingPlaceholdersInString:optionalText values:values];
     return [title stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+}
+
++ (BOOL)formatUsesPlaybackTime:(NSString *)format
+{
+    NSString *formatString = format ?: SNPDefaultMenubarFormat;
+    return [formatString containsString:@"{position}"] || [formatString containsString:@"{duration}"] || [formatString containsString:@"{remaining}"];
 }
 
 + (NSString *)stringByRenderingOptionalSegmentsInString:(NSString *)string values:(NSDictionary<NSString *, NSString *> *)values

--- a/Spotify Now PlayingTests/Spotify_Now_PlayingTests.m
+++ b/Spotify Now PlayingTests/Spotify_Now_PlayingTests.m
@@ -61,4 +61,24 @@
     XCTAssertEqualObjects(withoutAlbum, @"Sweet Disposition");
 }
 
+- (void)testPlaybackTimePlaceholders {
+    NSString *title = [SNPMenuBarTitleFormatter titleWithFormat:@"{position}/{duration} {remaining} {title}"
+                                                      songTitle:@"Sweet Disposition"
+                                                         artist:@"The Temper Trap"
+                                                          album:@"Conditions"
+                                                       position:@"1:23"
+                                                       duration:@"3:45"
+                                                      remaining:@"-2:22"
+                                                        playing:YES];
+
+    XCTAssertEqualObjects(title, @"1:23/3:45 -2:22 Sweet Disposition");
+}
+
+- (void)testPlaybackTimePlaceholderDetection {
+    XCTAssertFalse([SNPMenuBarTitleFormatter formatUsesPlaybackTime:SNPDefaultMenubarFormat]);
+    XCTAssertTrue([SNPMenuBarTitleFormatter formatUsesPlaybackTime:@"{position} {title}"]);
+    XCTAssertTrue([SNPMenuBarTitleFormatter formatUsesPlaybackTime:@"{duration} {title}"]);
+    XCTAssertTrue([SNPMenuBarTitleFormatter formatUsesPlaybackTime:@"{remaining} {title}"]);
+}
+
 @end

--- a/Spotify Now PlayingTests/Spotify_Now_PlayingTests.m
+++ b/Spotify Now PlayingTests/Spotify_Now_PlayingTests.m
@@ -7,6 +7,7 @@
 //
 
 #import <XCTest/XCTest.h>
+#import "../Spotify Now Playing/SNPMenuBarTitleFormatter.h"
 
 @interface Spotify_Now_PlayingTests : XCTestCase
 
@@ -14,24 +15,50 @@
 
 @implementation Spotify_Now_PlayingTests
 
-- (void)setUp {
-    // Put setup code here. This method is called before the invocation of each test method in the class.
+- (void)testDefaultFormatUsesPlaybackSymbolArtistAndTitle {
+    NSString *title = [SNPMenuBarTitleFormatter titleWithFormat:SNPDefaultMenubarFormat
+                                                      songTitle:@"Sweet Disposition"
+                                                         artist:@"The Temper Trap"
+                                                          album:@"Conditions"
+                                                        playing:YES];
+
+    XCTAssertEqualObjects(title, @"▶ The Temper Trap - Sweet Disposition");
 }
 
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
+- (void)testOptionalSegmentIsHiddenWhenPlaceholderIsEmpty {
+    NSString *title = [SNPMenuBarTitleFormatter titleWithFormat:SNPDefaultMenubarFormat
+                                                      songTitle:@"Sweet Disposition"
+                                                         artist:@""
+                                                          album:@"Conditions"
+                                                        playing:YES];
+
+    XCTAssertEqualObjects(title, @"▶ Sweet Disposition");
 }
 
-- (void)testExample {
-    // This is an example of a functional test case.
-    // Use XCTAssert and related functions to verify your tests produce the correct results.
+- (void)testPausedPlaybackSymbol {
+    NSString *title = [SNPMenuBarTitleFormatter titleWithFormat:@"{playbackSymbol} {title}"
+                                                      songTitle:@"Sweet Disposition"
+                                                         artist:@"The Temper Trap"
+                                                          album:@"Conditions"
+                                                        playing:NO];
+
+    XCTAssertEqualObjects(title, @"⏸ Sweet Disposition");
 }
 
-- (void)testPerformanceExample {
-    // This is an example of a performance test case.
-    [self measureBlock:^{
-        // Put the code you want to measure the time of here.
-    }];
+- (void)testAlbumOptionalSegment {
+    NSString *withAlbum = [SNPMenuBarTitleFormatter titleWithFormat:@"{title}[ ({album})]"
+                                                          songTitle:@"Sweet Disposition"
+                                                             artist:@"The Temper Trap"
+                                                              album:@"Conditions"
+                                                            playing:YES];
+    NSString *withoutAlbum = [SNPMenuBarTitleFormatter titleWithFormat:@"{title}[ ({album})]"
+                                                             songTitle:@"Sweet Disposition"
+                                                                artist:@"The Temper Trap"
+                                                                 album:@""
+                                                               playing:YES];
+
+    XCTAssertEqualObjects(withAlbum, @"Sweet Disposition (Conditions)");
+    XCTAssertEqualObjects(withoutAlbum, @"Sweet Disposition");
 }
 
 @end


### PR DESCRIPTION
## Summary

This PR replaces the fixed menubar title options with a persisted, user-configurable format string. It also adds playback-time placeholders, an optional rainbow title effect, and fixes a pre-existing crash risk in the artwork menu item update path.

## Screenshots / Demo

### Options menu

<img width="474" height="152" alt="Snipaste_2026-04-25_05-54-04" src="https://github.com/user-attachments/assets/02f43969-eb32-47a6-a42a-fdc4f55a9b68" />

### Menubar format editor

<img width="459" height="396" alt="Snipaste_2026-04-25_05-52-10" src="https://github.com/user-attachments/assets/a43a53b2-a8df-40ec-8d35-1c72fcef1bb0" />

### Rainbow title settings

<img width="458" height="368" alt="Snipaste_2026-04-25_05-53-38" src="https://github.com/user-attachments/assets/668eac98-b21c-412d-88d9-d83359f6879d" />

### Rainbow title demo

https://github.com/user-attachments/assets/6435cde9-b795-4aa5-9aee-2e3dfe94c7ab

## Changes

### Menubar title formatting

- Adds `SNPMenuBarTitleFormatter` for rendering menubar titles from a format string.
- Adds a persisted menubar format preference.
- Uses this default format:

  `{playbackSymbol} [{artist} - ]{title}`

- Supports placeholders:
  - `{playbackSymbol}`
  - `{artist}`
  - `{title}`
  - `{album}`
  - `{position}`
  - `{duration}`
  - `{remaining}`

- Supports optional segments with `[ ... ]`.
  - Optional segments are hidden when any placeholder inside the segment is empty.
  - Example: `[{artist} - ]{title}` hides the artist separator when there is no artist.
- Adds a `Restore Defaults` button to the format editor.
- Removes the previous separate menubar options for showing the play icon and hiding the song title, since both are now covered by the format string.

### Playback time placeholders

- Adds support for elapsed time, duration, and remaining time in the menubar format.
- Reads Spotify playback position and track duration when needed.
- Avoids querying Spotify every second by caching playback metadata and estimating the current position locally while playback continues.
- Starts the periodic menubar title refresh only when the active format uses playback-time placeholders.

### Rainbow title effect

- Adds an optional `Rainbow title effect` menu item.
- The effect is disabled by default.
- Adds a compact settings dialog for:
  - Hue spacing
  - Saturation
- Keeps brightness fixed at 100%.
- Applies the animated attributed title only while music is playing.
- Restores the plain title when the effect is disabled, playback pauses, or the title is unavailable.

### Pre-existing artwork crash fix

- Fixes a pre-existing crash risk where album artwork menu item updates could run from `NSURLSession` background callbacks.
- Moves `NSMenuItem` and `NSImage` updates for artwork loading onto the main queue.
- This keeps AppKit UI mutation on the main thread while preserving the existing artwork loading behavior.

### Documentation and tests

- Updates the README with the new format syntax, available placeholders, optional segments, and rainbow effect setting.
- Adds unit tests for:
  - Default title formatting
  - Optional format segments
  - Playback symbol rendering
  - Album placeholder rendering
  - Playback time placeholders
  - Detection of formats that require playback-time refresh

## Testing

- Ran the unit test target with:

  `xcodebuild test -project "Spotify Now Playing.xcodeproj" -scheme "Spotify Now Playing" -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO -only-testing:"Spotify Now PlayingTests"`

- All tests passed.
- Also verified that a Release archive builds successfully locally.